### PR TITLE
Run Kubernetes Jobs from Concourse

### DIFF
--- a/bin/in
+++ b/bin/in
@@ -8,13 +8,45 @@ echo "Starting in"
 payload="$(mktemp "$TMPDIR/k8s-resource-request.XXXXXX")"
 cat > "$payload" <&0
 
+# This looks inside the logs of the pod that ran this job to find out if it
+# was successful or not
+check_logs_and_print_message_and_exit() {
+    JOB_NAME=$1
+    POD=`$KUBECTL get pods -a --selector="name=$JOB_NAME" -o 'jsonpath={.items[0].metadata.name}'`
+    LOG_MSG="* To see logs, run: $KUBECTL logs $POD"
+    logs=`$KUBECTL logs $POD`
+
+    # Extract lines that start with Job exited with code <code>, where <code>
+    # is a one-digit wildcard. The following variable "all_log_lines_with_exit_codes"
+    # looks like "Job exited with code 0 Job exited with code -1"
+    all_log_lines_with_exit_codes=`echo $logs | grep -o '\bJob exited with code .\w*'`
+
+    # This extracts the exit code from the first line in the above variable
+    reliable_exit_code=$(
+    	echo $all_log_lines_with_exit_codes |
+    	sed "s/Job/\\`echo -e '\n\r'`Job/g" |
+    	tail -n 2 | head -n 1 | tail -c 3 | head -c 1
+		)
+
+    if [ "$reliable_exit_code" == "0" ]; then
+        echo -e "\033[92m* Your job succeeded\033[0m"
+        echo "$LOG_MSG"
+        echo "In complete"
+        echo "$result" | jq -s add  >&3
+    else
+        echo -e "\033[91m* Welp, your job failed.\033[0m"
+        echo "$LOG_MSG"
+        echo "In complete"
+        echo "$result" | jq -s add  >&3
+        exit 1
+    fi
+}
 cd "$1"
 
 mkdir -p /root/.kube
 
 KUBE_URL=$(jq -r .source.cluster_url < "$payload")
 NAMESPACE=$(jq -r .source.namespace < "$payload")
-
 KUBECTL="/usr/local/bin/kubectl --server=$KUBE_URL --namespace=$NAMESPACE"
 
 # configure SSL Certs if available
@@ -44,10 +76,27 @@ else
 
     RESOURCE="$RESOURCE_TYPE/$RESOURCE_NAME"
 
-    IMG=$($KUBECTL get -o json "$RESOURCE" | jq -r '.spec.template.spec.containers[0].image')
+    RUN_JOB=$(jq -r .params.run_job < "$payload")
+    DRY_RUN=$(jq -r .params.dry_run < "$payload")
 
-    result="$(jq -n "{version:{container:\"$IMG\"}}")"
+    if [[ "$RESOURCE_TYPE" = 'job' ]]; then
+        JOB_NAME=$(jq -r .source.job_name < "$payload")
+        while [ true ]; do
+            succeeded=`$KUBECTL get jobs $JOB_NAME -o 'jsonpath={.status.succeeded}'`
+            failed=`$KUBECTL get jobs $JOB_NAME -o 'jsonpath={.status.failed}'`
+            if [[ "$succeeded" == "1" ]]; then
+                check_logs_and_print_message_and_exit "$JOB_NAME";
+                break;
+            elif [[ "$failed" -gt "0" ]]; then
+                check_logs_and_print_message_and_exit "$JOB_NAME";
+                break;
+            fi
+            sleep 1 # So that log output in Concourse doesn't go whack
+        done
+    else    # Kube deployments
+        IMG=$($KUBECTL get -o json "$RESOURCE" | jq -r '.spec.template.spec.containers[0].image')
+        result="$(jq -n "{version:{container:\"$IMG\"}}")"
+        echo "In complete"
+        echo "$result" | jq -s add  >&3
+    fi
 fi
-
-echo "In complete"
-echo "$result" | jq -s add  >&3

--- a/bin/out
+++ b/bin/out
@@ -9,6 +9,11 @@ echo "Starting out"
 payload="$(mktemp "$TMPDIR/k8s-resource-request.XXXXXX")"
 cat > "$payload" <&0
 
+DRY_RUN=$(jq -r .params.dry_run < "$payload")
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "********************** Running in DRY_RUN mode **********************"
+fi
+
 rollback() {
     DEPLOYMENT=$1
     DRY_RUN=$2
@@ -57,8 +62,49 @@ start_job() {
     [ -n "$IMAGE" ] || exit 1
     [ -n "$UID" ] || exit 1
 
+    echo "Running: cat "$JOB" | IMAGE=$IMAGE UID=$UID envsubst | $KUBECTL create --record -f -"
     if [[ "$DRY_RUN" == "null" ]] || [[ "$DRY_RUN" == "false" ]]; then
         cat "$JOB" | IMAGE=$IMAGE UID=$UID envsubst | $KUBECTL create --record -f -
+    fi
+}
+
+create_and_run_job() {
+    JOB_NAME=$1
+    DEPLOYMENT_PATH=$2
+    DRY_RUN=$3
+
+    [ -n "$JOB_NAME" ] || exit 1
+    [ -n "$DEPLOYMENT_PATH" ] || exit 1
+
+    echo "Running: cat "${DEPLOYMENT_PATH}" | $KUBECTL create --record -f -"
+    if [[ "$DRY_RUN" == "null" ]] || [[ "$DRY_RUN" == "false" ]]; then
+        cat "${DEPLOYMENT_PATH}" | $KUBECTL create --record -f -
+
+        # Wait for the state of the pod to change from Pending, or exit after
+        # 60 seconds (to prevent an infinite loop)
+        start_time=$(date +%s) # time at start of while loop
+        end_time=$(($start_time+60)) # time at which we should break out of the while true loop
+
+        # Wait for the state of the pod to change from Pending
+        while [ true ]; do
+            phase=`$KUBECTL get pods -a --selector="name=$JOB_NAME" -o 'jsonpath={.items[0].status.phase}' || 'false'`
+            current_time=$(date +%s)
+
+            if [[ $current_time > $end_time ]]; then
+                # This means that the pod could not start within 60 seconds of the
+                # job being created. Normally, this should be enough time it to
+                # start. This indicates there is a problem with the system. The dev
+                # can try re-running and investigate further if that doesn't succeed.
+                echo -e "\033[91m* Pod was not able to start. Exiting with error. Please run job again.\033[0m"
+                exit 1
+            fi
+
+            if [[ "$phase" != 'Pending' ]]; then
+                break
+            fi
+
+            sleep 1 # So that log output in Concourse doesn't go whack
+        done
     fi
 }
 
@@ -94,9 +140,9 @@ fi
 export KUBECTL
 
 ROLLBACK=$(jq -r .params.rollback < "$payload")
+RUN_JOB=$(jq -r .params.run_job < "$payload")
 RESOURCE_TYPE=$(jq -r .source.resource_type < "$payload")
 RESOURCE_NAME=$(jq -r .source.resource_name < "$payload")
-DRY_RUN=$(jq -r .params.dry_run < "$payload")
 
 if [[ -z "$RESOURCE_TYPE" ]]; then
     RESOURCE_TYPE=$(jq -r .params.resource_type < "$payload")
@@ -106,7 +152,13 @@ if [[ -z "$RESOURCE_NAME" ]]; then
     RESOURCE_TYPE=$(jq -r .params.resource_name < "$payload")
 fi
 
-if [[ "$RESOURCE_TYPE" = 'deployment' ]]; then
+if [[ "$RESOURCE_TYPE" = 'job' ]]; then
+    if [[ "$RUN_JOB" = "true" ]]; then
+        JOB_NAME=$(jq -r .source.job_name < "$payload")
+        DEPLOYMENT_PATH=$(jq -r .source.deployment_file < "$payload")
+        create_and_run_job "$JOB_NAME" "$DEPLOYMENT_PATH" "$DRY_RUN";
+    fi
+elif [[ "$RESOURCE_TYPE" = 'deployment' ]]; then
     if [[ "$ROLLBACK" = "true" ]]; then
         rollback "$RESOURCE_NAME" "$DRY_RUN";
     else

--- a/push_docker.sh
+++ b/push_docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+response="$(docker build .)"
+IMAGE_ID=$(echo $response | awk 'NF>1{print $NF}')
+echo "******** Pushing docker image ID $IMAGE_ID ********"
+docker tag $IMAGE_ID periscopedata/concourse-kubernetes-resource:latest
+docker push periscopedata/concourse-kubernetes-resource:latest


### PR DESCRIPTION
This PR enables this resource to run Kubernetes jobs.

**Inputs**
1. job_name
2. deployment_file

**Flow**
1. Creates the Kube job
2. Waits for the status to become Pending
3. Attaches itself to the Kube pod until the job completes (succeeds or fails)
4. Based on this result, it returns the status to Concourse

**Contributions of this PR**
1. Run Kubernetes Jobs from Concourse
2. Ability to use use source control for deployment related stuff (since it reads clocktower to get the job config)